### PR TITLE
Update for Ruby 3. 

### DIFF
--- a/jcapiv1/lib/jcapiv1/api_client.rb
+++ b/jcapiv1/lib/jcapiv1/api_client.rb
@@ -264,7 +264,7 @@ module JCAPIv1
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      @config.base_url + path
     end
 
     # Builds the HTTP request body

--- a/jcapiv1/lib/jcapiv1/configuration.rb
+++ b/jcapiv1/lib/jcapiv1/configuration.rb
@@ -174,8 +174,7 @@ module JCAPIv1
     end
 
     def base_url
-      url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
     end
 
     # Gets API key (with prefix if set).

--- a/jcapiv2/lib/jcapiv2/api_client.rb
+++ b/jcapiv2/lib/jcapiv2/api_client.rb
@@ -264,7 +264,7 @@ module JCAPIv2
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      @config.base_url + path
     end
 
     # Builds the HTTP request body

--- a/jcapiv2/lib/jcapiv2/configuration.rb
+++ b/jcapiv2/lib/jcapiv2/configuration.rb
@@ -174,8 +174,7 @@ module JCAPIv2
     end
 
     def base_url
-      url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
URI.encode is removed and URI.encode_www_form_component doesn't work exactly and isn't necessary here.